### PR TITLE
Realized I need to switch these for when we do a clean run

### DIFF
--- a/models/migration/draft_plan_members.sql
+++ b/models/migration/draft_plan_members.sql
@@ -16,7 +16,7 @@ MODEL (
 
 WITH max_id AS (
   SELECT COALESCE(MAX(id), 0) AS max_id_value
-  FROM dmptool.planMembers
+  FROM migration.plan_members
 ),
 
 sequenced_source_data AS (

--- a/models/migration/draft_plans.sql
+++ b/models/migration/draft_plans.sql
@@ -31,7 +31,7 @@ WITH default_template AS (
 
 max_id AS (
   SELECT COALESCE(MAX(id), 0) AS max_id_value
-  FROM dmptool.plans
+  FROM migration.plans
 ),
 
 sequenced_source_data AS (

--- a/models/migration/draft_project_fundings.sql
+++ b/models/migration/draft_project_fundings.sql
@@ -20,7 +20,7 @@ MODEL (
 
 WITH max_id AS (
   SELECT COALESCE(MAX(id), 0) AS max_id_value
-  FROM dmptool.projectFundings
+  FROM migration.project_fundings
 ),
 
 sequenced_source_data AS (

--- a/models/migration/draft_project_members.sql
+++ b/models/migration/draft_project_members.sql
@@ -20,7 +20,7 @@ MODEL (
 
 WITH max_id AS (
   SELECT COALESCE(MAX(id), 0) AS max_id_value
-  FROM dmptool.projectMembers
+  FROM migration.project_members
 ),
 
 sequenced_source_data AS (

--- a/models/migration/draft_projects.sql
+++ b/models/migration/draft_projects.sql
@@ -21,7 +21,7 @@ MODEL (
 
 WITH max_id AS (
   SELECT COALESCE(MAX(id), 0) AS max_id_value
-  FROM dmptool.projects
+  FROM migration.projects
 ),
 
 sequenced_source_data AS (

--- a/models/migration/plans.sql
+++ b/models/migration/plans.sql
@@ -37,7 +37,7 @@ SELECT
   TRIM(p.title) AS title,
   p.visibility,
   p.status,
-  p.dmp_id AS dmpId,
+  COALESCE(p.dmp_id, CONCAT('TEMP-', p.id)) AS dmpId,
   CASE WHEN p.dmp_id IS NOT NULL THEN u.id ELSE NULL END AS registeredById,
   CASE WHEN p.dmp_id IS NOT NULL THEN p.updated_at ELSE NULL END AS registered,
   p.language AS languageId,


### PR DESCRIPTION
I was running against the dev DB which already had the regular project and plans migrated over and realized that these files should reference the migration DB instead to ensure the ids are unique.